### PR TITLE
Feature - OpenSSL encryption compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "ext-mbstring": "*",
         "ext-iconv": "*",
         "ext-spl": "*",
+        "ext-openssl": "*",
         "phpunit/phpunit": "^4.7",
         "phpunit/php-code-coverage": "^2.2",
         "squizlabs/php_codesniffer": "^2.3"

--- a/src/Robin/Ntlm/Crypt/Des/OpenSslDesEncrypter.php
+++ b/src/Robin/Ntlm/Crypt/Des/OpenSslDesEncrypter.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Robin NTLM
+ *
+ * @copyright 2015 Robin Powered, Inc.
+ * @link https://robinpowered.com/
+ */
+
+namespace Robin\Ntlm\Crypt\Des;
+
+use InvalidArgumentException;
+use Robin\Ntlm\Crypt\CipherMode;
+use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
+
+/**
+ * An engine used to encrypt data using the DES standard algorithm and
+ * implemented using the PHP "openssl" extension.
+ *
+ * @link http://php.net/openssl
+ */
+class OpenSslDesEncrypter implements DesEncrypterInterface
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * The default OpenSSL encryption options.
+     *
+     * @type int
+     */
+    const DEFAULT_OPENSSL_OPTIONS = OPENSSL_RAW_DATA;
+
+
+    /**
+     * Properties
+     */
+
+    /**
+     * A map of {@link CipherMode}s to the "openssl" extension equivalents.
+     */
+    private static $cipher_mode_map = [
+        CipherMode::CBC => 'des-cbc',
+        CipherMode::CFB => 'des-cfb',
+        CipherMode::ECB => 'des-ecb',
+        CipherMode::OFB => 'des-ofb',
+    ];
+
+    /**
+     * Whether or not to zero-byte pad the data before encrypting for some
+     * cipher modes.
+     *
+     * @type bool
+     */
+    private $zero_pad;
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Constructor
+     *
+     * @param bool $zero_pad Whether or not to zero-byte pad the data before
+     *   encrypting for some cipher modes.
+     */
+    public function __construct($zero_pad = true)
+    {
+        $this->zero_pad = $zero_pad;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function encrypt($key, $data, $mode, $initialization_vector)
+    {
+        if (isset(self::$cipher_mode_map[$mode])) {
+            $mode = self::$cipher_mode_map[$mode];
+        } else {
+            throw new InvalidArgumentException('Unknown cipher mode "'. $mode .'"');
+        }
+
+        $options = $this->getOpenSslEncryptionOptions();
+
+        $encrypted = openssl_encrypt($data, $mode, $key, $options, $initialization_vector);
+
+        if (false === $encrypted) {
+            throw CryptographicFailureException::forReasonCode(
+                CryptographicFailureException::CODE_FOR_ENCRYPTION_FAILURE
+            );
+        }
+
+        return $encrypted;
+    }
+
+    /**
+     * Gets the OpenSSL encryption options.
+     *
+     * @return int The options to use in an OpenSSL encryption call.
+     */
+    private function getOpenSslEncryptionOptions()
+    {
+        $options = self::DEFAULT_OPENSSL_OPTIONS;
+
+        if ($this->zero_pad) {
+            $options = $options | OPENSSL_ZERO_PADDING;
+        }
+
+        return $options;
+    }
+}

--- a/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
+++ b/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Robin NTLM
+ *
+ * @copyright 2015 Robin Powered, Inc.
+ * @link https://robinpowered.com/
+ */
+
+namespace Robin\Ntlm\Crypt\Random;
+
+use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
+
+/**
+ * A cryptographically secure random byte generator implemented using the PHP
+ * "openssl" extension.
+ *
+ * @link http://php.net/openssl
+ */
+class OpenSslRandomByteGenerator implements RandomByteGeneratorInterface
+{
+
+    /**
+     * Methods
+     */
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate($size)
+    {
+        $generated = openssl_random_pseudo_bytes($size, $strong);
+
+        if (false === $generated || strlen($generated) !== $size || false === $strong) {
+            throw CryptographicFailureException::forReasonCode(
+                CryptographicFailureException::CODE_FOR_RANDOM_DATA_GENERATION_FAILURE
+            );
+        }
+
+        return $generated;
+    }
+}


### PR DESCRIPTION
Sooooo the [**mcrypt** library](http://mcrypt.sourceforge.net/) has been abandoned since 2003 (... woah), and [even though it will still exist for the foreseeable future](http://thefsb.tumblr.com/post/110639027905/custodians-of-php-vote-to-keep-a-crypto-lib), it really shouldn't be the only option for the cryptographic internals of this project.

That being said, this PR implements the cryptographic interfaces included in this project using the [**OpenSSL** extension](http://php.net/openssl).

It was a bit tricky getting the two libraries to match up exactly, but luckily there were some [community posts to make things a bit easier](http://thefsb.tumblr.com/post/110749271235/using-opensslendecrypt-in-php-instead-of).

---

_PS: This is why interfaces are so beautiful._ :heart:
