### PR TITLE
Bugfix - NTLMv1 DES key expansion

### DIFF
--- a/src/Robin/Ntlm/Crypt/Des/AbstractDesEncrypter.php
+++ b/src/Robin/Ntlm/Crypt/Des/AbstractDesEncrypter.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Robin NTLM
+ *
+ * @copyright 2015 Robin Powered, Inc.
+ * @link https://robinpowered.com/
+ */
+
+namespace Robin\Ntlm\Crypt\Des;
+
+use SplFixedArray;
+
+/**
+ * {@inheritDoc}
+ *
+ * Provides an abstraction for common NTLM required operations, such as key
+ * expansion and normalization.
+ */
+abstract class AbstractDesEncrypter implements DesEncrypterInterface
+{
+
+    /**
+     * Properties
+     */
+
+    /**
+     * Whether or not to expand and normalize the key before encrypting.
+     *
+     * @type bool
+     */
+    private $expand_and_normalize_keys;
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Constructor
+     *
+     * @param bool $expand_and_normalize_keys Whether or not to expand and
+     *   normalize the key before encrypting.
+     */
+    public function __construct($expand_and_normalize_keys = true)
+    {
+        $this->expand_and_normalize_keys = $expand_and_normalize_keys;
+    }
+
+    /**
+     * Process a key for DES encryption.
+     *
+     * Optionally performs an expansion and normalization process to the key.
+     *
+     * @param string $raw_key The raw key.
+     * @return string The processed key.
+     */
+    protected function processKey($raw_key)
+    {
+        $key = $raw_key;
+
+        if ($this->expand_and_normalize_keys) {
+            $key = self::expand56BitKeyTo64BitKey($key, true);
+        }
+
+        return $key;
+    }
+
+    /**
+     * Expands a 56-bit key to a full 64-bit key for DES encryption.
+     *
+     * @link http://php.net/manual/en/ref.hash.php#84587 Implementation basis.
+     * @link https://github.com/jclulow/node-smbhash/blob/edc48e2b/lib/common.js
+     *   Inspired by Joshua Clulow's work.
+     * @param string $string_key The 56-bit key to expand.
+     * @param bool $set_parity Whether or not to set parity for each byte.
+     * @return string The expanded key.
+     */
+    private static function expand56BitKeyTo64BitKey($string_key, $set_parity = true)
+    {
+        $byte_array_56 = new SplFixedArray(7);
+        $byte_array_64 = new SplFixedArray(8);
+        $key_64bit = '';
+
+        // Get the byte value of each ASCII character in the string
+        for ($i = 0; $i < $byte_array_56->getSize(); $i++) {
+            $byte_array_56[$i] = isset($string_key[$i]) ? ord($string_key[$i]) : 0;
+        }
+
+        $byte_array_64[0] = $byte_array_56[0] & 254;
+        $byte_array_64[1] = ($byte_array_56[0] << 7) | ($byte_array_56[1] >> 1);
+        $byte_array_64[2] = ($byte_array_56[1] << 6) | ($byte_array_56[2] >> 2);
+        $byte_array_64[3] = ($byte_array_56[2] << 5) | ($byte_array_56[3] >> 3);
+        $byte_array_64[4] = ($byte_array_56[3] << 4) | ($byte_array_56[4] >> 4);
+        $byte_array_64[5] = ($byte_array_56[4] << 3) | ($byte_array_56[5] >> 5);
+        $byte_array_64[6] = ($byte_array_56[5] << 2) | ($byte_array_56[6] >> 6);
+        $byte_array_64[7] = $byte_array_56[6] << 1;
+
+        foreach ($byte_array_64 as $byte_val) {
+            // Optionally set parity for each byte
+            $byte_val = $set_parity ? self::setParityBit($byte_val) : $byte_val;
+
+            $key_64bit .= chr($byte_val);
+        }
+
+        return $key_64bit;
+    }
+
+    /**
+     * Set an odd parity bit for a given byte, in least-significant position.
+     *
+     * @param int $byte An 8-bit byte value.
+     * @return int An 8-bit byte value.
+     */
+    private static function setParityBit($byte)
+    {
+        $parity = 1;
+
+        for ($i = 1; $i < 8; $i++) {
+            $parity = ($parity + (($byte >> $i) & 1)) %2;
+        }
+
+        $byte = $byte | ($parity & 1);
+
+        return $byte;
+    }
+}

--- a/src/Robin/Ntlm/Crypt/Des/AbstractDesEncrypter.php
+++ b/src/Robin/Ntlm/Crypt/Des/AbstractDesEncrypter.php
@@ -108,6 +108,8 @@ abstract class AbstractDesEncrypter implements DesEncrypterInterface
     /**
      * Set an odd parity bit for a given byte, in least-significant position.
      *
+     * @link https://github.com/jclulow/node-smbhash/blob/edc48e2b/lib/common.js
+     *   Implementation basis.
      * @param int $byte An 8-bit byte value.
      * @return int An 8-bit byte value.
      */

--- a/src/Robin/Ntlm/Crypt/Des/McryptDesEncrypter.php
+++ b/src/Robin/Ntlm/Crypt/Des/McryptDesEncrypter.php
@@ -11,7 +11,6 @@ namespace Robin\Ntlm\Crypt\Des;
 use InvalidArgumentException;
 use Robin\Ntlm\Crypt\CipherMode;
 use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
-use UnexpectedValueException;
 
 /**
  * An engine used to encrypt data using the DES standard algorithm and
@@ -19,7 +18,7 @@ use UnexpectedValueException;
  *
  * @link http://php.net/mcrypt
  */
-class McryptDesEncrypter implements DesEncrypterInterface
+class McryptDesEncrypter extends AbstractDesEncrypter implements DesEncrypterInterface
 {
 
     /**
@@ -51,6 +50,8 @@ class McryptDesEncrypter implements DesEncrypterInterface
         } else {
             throw new InvalidArgumentException('Unknown cipher mode "'. $mode .'"');
         }
+
+        $key = $this->processKey($key);
 
         $encrypted = mcrypt_encrypt(MCRYPT_DES, $key, $data, $mode, $initialization_vector);
 

--- a/src/Robin/Ntlm/Crypt/Des/OpenSslDesEncrypter.php
+++ b/src/Robin/Ntlm/Crypt/Des/OpenSslDesEncrypter.php
@@ -18,7 +18,7 @@ use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
  *
  * @link http://php.net/openssl
  */
-class OpenSslDesEncrypter implements DesEncrypterInterface
+class OpenSslDesEncrypter extends AbstractDesEncrypter implements DesEncrypterInterface
 {
 
     /**
@@ -65,9 +65,13 @@ class OpenSslDesEncrypter implements DesEncrypterInterface
      *
      * @param bool $zero_pad Whether or not to zero-byte pad the data before
      *   encrypting for some cipher modes.
+     * @param bool $expand_and_normalize_keys Whether or not to expand and
+     *   normalize the key before encrypting.
      */
-    public function __construct($zero_pad = true)
+    public function __construct($zero_pad = true, $expand_and_normalize_keys = true)
     {
+        parent::__construct($expand_and_normalize_keys);
+
         $this->zero_pad = $zero_pad;
     }
 
@@ -83,6 +87,8 @@ class OpenSslDesEncrypter implements DesEncrypterInterface
         }
 
         $options = $this->getOpenSslEncryptionOptions();
+
+        $key = $this->processKey($key);
 
         $encrypted = openssl_encrypt($data, $mode, $key, $options, $initialization_vector);
 

--- a/src/Robin/Ntlm/Hasher/LmHasher.php
+++ b/src/Robin/Ntlm/Hasher/LmHasher.php
@@ -14,7 +14,6 @@ use Robin\Ntlm\Credential\Password;
 use Robin\Ntlm\Crypt\CipherMode;
 use Robin\Ntlm\Crypt\Des\DesEncrypterInterface;
 use Robin\Ntlm\Crypt\Random\RandomByteGeneratorInterface;
-use SplFixedArray;
 
 /**
  * Uses the "LM hash" computation strategy to hash a {@link Password} credential
@@ -134,10 +133,8 @@ class LmHasher implements HasherInterface
         $binary_hash = array_reduce(
             $halves,
             function ($result, $half) {
-                $expanded = static::expand56BitKeyTo64BitKey($half);
-
                 return $result . $this->des_encrypter->encrypt(
-                    $expanded,
+                    $half,
                     static::ENCRYPT_DATA_CONSTANT,
                     CipherMode::ECB,
                     $this->random_byte_generator->generate(static::RANDOM_BINARY_STRING_LENGTH)
@@ -147,40 +144,5 @@ class LmHasher implements HasherInterface
         );
 
         return Hash::fromBinaryString($binary_hash, HashType::LM);
-    }
-
-    /**
-     * Expands a 56-bit key to a full 64-bit key for DES encryption.
-     *
-     * @link http://php.net/manual/en/ref.hash.php#84587 Implementation basis.
-     * @link https://github.com/jclulow/node-smbhash/blob/edc48e2b93067/lib/common.js Inspired by Joshua Clulow's work.
-     * @param string $string_key The 56-bit key to expand
-     * @return string
-     */
-    public static function expand56BitKeyTo64BitKey($string_key)
-    {
-        $byte_array_56 = new SplFixedArray(7);
-        $byte_array_64 = new SplFixedArray(8);
-        $key_64bit = '';
-
-        // Get the byte value of each ASCII character in the string
-        for ($i = 0; $i < $byte_array_56->getSize(); $i++) {
-            $byte_array_56[$i] = isset($string_key[$i]) ? ord($string_key[$i]) : 0;
-        }
-
-        $byte_array_64[0] = $byte_array_56[0] & 254;
-        $byte_array_64[1] = ($byte_array_56[0] << 7) | ($byte_array_56[1] >> 1);
-        $byte_array_64[2] = ($byte_array_56[1] << 6) | ($byte_array_56[2] >> 2);
-        $byte_array_64[3] = ($byte_array_56[2] << 5) | ($byte_array_56[3] >> 3);
-        $byte_array_64[4] = ($byte_array_56[3] << 4) | ($byte_array_56[4] >> 4);
-        $byte_array_64[5] = ($byte_array_56[4] << 3) | ($byte_array_56[5] >> 5);
-        $byte_array_64[6] = ($byte_array_56[5] << 2) | ($byte_array_56[6] >> 6);
-        $byte_array_64[7] = $byte_array_56[6] << 1;
-
-        foreach ($byte_array_64 as $byte_val) {
-            $key_64bit .= chr($byte_val);
-        }
-
-        return $key_64bit;
     }
 }

--- a/src/Robin/Ntlm/Hasher/LmHasher.php
+++ b/src/Robin/Ntlm/Hasher/LmHasher.php
@@ -13,7 +13,6 @@ use Robin\Ntlm\Credential\HashType;
 use Robin\Ntlm\Credential\Password;
 use Robin\Ntlm\Crypt\CipherMode;
 use Robin\Ntlm\Crypt\Des\DesEncrypterInterface;
-use Robin\Ntlm\Crypt\Random\RandomByteGeneratorInterface;
 
 /**
  * Uses the "LM hash" computation strategy to hash a {@link Password} credential
@@ -53,14 +52,6 @@ class LmHasher implements HasherInterface
     const PASSWORD_SLICE_LENGTH = 7;
 
     /**
-     * The length of the randomly generated binary string used for generating
-     * each piece of the resulting hash.
-     *
-     * @type int
-     */
-    const RANDOM_BINARY_STRING_LENGTH = 8;
-
-    /**
      * The constant known ASCII text to encrypt with the generated keys.
      *
      * @link https://tools.ietf.org/html/rfc2433#appendix-A.3
@@ -82,14 +73,6 @@ class LmHasher implements HasherInterface
      */
     private $des_encrypter;
 
-    /**
-     * The generator used to generate cryptographically secure random bytes to
-     * provide an initialization vector for encryption.
-     *
-     * @type RandomByteGeneratorInterface
-     */
-    private $random_byte_generator;
-
 
     /**
      * Methods
@@ -100,16 +83,10 @@ class LmHasher implements HasherInterface
      *
      * @param DesEncrypterInterface $des_encrypter The DES encryption engine
      *   used to generate the hash.
-     * @param RandomByteGeneratorInterface $random_byte_generator Used to
-     *   generate cryptographically secure random bytes to provide an
-     *   initialization vector for encryption.
      */
-    public function __construct(
-        DesEncrypterInterface $des_encrypter,
-        RandomByteGeneratorInterface $random_byte_generator
-    ) {
+    public function __construct(DesEncrypterInterface $des_encrypter)
+    {
         $this->des_encrypter = $des_encrypter;
-        $this->random_byte_generator = $random_byte_generator;
     }
 
     /**
@@ -137,7 +114,7 @@ class LmHasher implements HasherInterface
                     $half,
                     static::ENCRYPT_DATA_CONSTANT,
                     CipherMode::ECB,
-                    $this->random_byte_generator->generate(static::RANDOM_BINARY_STRING_LENGTH)
+                    '' // DES-ECB expects a 0-byte-length initialization vector
                 );
             },
             ''

--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -322,14 +322,11 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
         $binary_data = array_reduce(
             $key_blocks,
             function ($result, $key_block) use ($data) {
-                // Generate an initialization vector equal to the length of the nonce
-                $initialization_vector = $this->random_byte_generator->generate(strlen($data));
-
                 return $result . $this->des_encrypter->encrypt(
                     $key_block,
                     $data,
                     CipherMode::ECB,
-                    $initialization_vector
+                    '' // DES-ECB expects a 0-byte-length initialization vector
                 );
             },
             ''


### PR DESCRIPTION
After 10+ hours of debugging, I finally found why NTLMv1 seemed to be failing... and reason is incredibly stupid and frustrating.

The **DES encryption** algorithm that is used in the NTLM protocol is a non-standard algorithm, in that it uses a special process to "expand" 56-bit (7-byte) keys to 64-bit (8-byte) keys. While implementing the LM hashing algorithm originally, [I made sure to include that expansion process](https://github.com/robinpowered/php-ntlm/blob/v0.2.0/src/Robin/Ntlm/Hasher/LmHasher.php#L152-L185). Unfortunately, I had made the original LM hasher way before putting together all of the other pieces that integrate to create a full NTLMv1 "Authenticate Message" encoding process. Because I had spent so much time in between those implementations, [I didn't remember to include that special key expansion and normalization process when using the DES encrypter to generate part of the LM/NT responses](https://github.com/robinpowered/php-ntlm/blob/v0.2.0/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php#L328-L333).

This is one of those "bugs" that is caused by oversight when fleshing out an implementation. Damn.

Anyway, in order to fix this bug, I've simply abstracted the key expansion bits into a common key processing piece that gets optionally called for all DES encryption processes, since that's the way that DES encryption is always used in the NTLM protocol.

Also, I had forgotten a small part of the processing originally that is intended to normalize keys by setting a parity bit for each byte in a DES key. [Thanks to some prior art](https://github.com/jclulow/node-smbhash/blob/edc48e2b93067f85fef762a3beba5abbf72a31d4/lib/common.js#L26-L39) (referenced in the method doc-block), that is now implemented.

Finally, thanks to some integration testing, I another oversight in the design of the LM hashing and DES encryption usage: I was generating a random "initialization vector" and providing it to the DES encrypter when using an ECB cipher mode... which doesn't make any sense, as the DES-ECB encryption cipher doesn't use a provided initialization vector (oops!). So, in order to "fix" that unnecessary operation, I've simply removed the old initialization vector generation when using DES-ECB. When doing so, I realized that the [`LmHasher`](https://github.com/robinpowered/php-ntlm/blob/v0.2.0/src/Robin/Ntlm/Hasher/LmHasher.php#L143) no longer needed the `RandomByteGeneratorInterface` dependency, as it was no longer being used, so I removed it! **The nice thing about this removal is that we'll no longer be generating random bytes when we don't need to, which will allow us to remove unnecessary calls that were actually taking up I/O time and entropy, so this is an optimization all around too.** :smile: 

Do to these new abstractions and dependency removals, the changes in this PR are actually **breaking backwards compatibility**. Luckily the library is still in a pre-1.0 "unstable" version phase, so a BC break like this is allowed (and somewhat expected).

Anyway, I'm beat now. My past several hours have had so much reverse engineering through message decoding that I'm absolutely toast. :bread: So I'm out for tonight.

_**PS**: I've done some integration tests, and now both the NTLMv1 and NTLMv2 processes work against an Exchange 2010 server running on Windows Server 2008._ :smiley: 
