### PR TITLE
Bugfix - Handling no LM hash

### DIFF
--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -211,6 +211,8 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
                 $server_challenge_nonce
             );
         } else {
+            // According to the spec, we're supposed to use the NT challenge response for the LM challenge response,
+            // if an LM challenge response isn't calculated
             $lm_challenge_response = $nt_challenge_response;
         }
 

--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -196,20 +196,22 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
             }
         }
 
-        if (null !== $lm_hash && $calculate_lm_response) {
-            $lm_challenge_response = $this->calculateLmResponse(
-                $lm_hash,
-                $client_challenge,
-                $server_challenge_nonce
-            );
-        }
-
         if (null !== $nt_hash && $calculate_nt_response) {
             $nt_challenge_response = $this->calculateNtResponse(
                 $nt_hash,
                 $client_challenge,
                 $server_challenge_nonce
             );
+        }
+
+        if (null !== $lm_hash && $calculate_lm_response) {
+            $lm_challenge_response = $this->calculateLmResponse(
+                $lm_hash,
+                $client_challenge,
+                $server_challenge_nonce
+            );
+        } else {
+            $lm_challenge_response = $nt_challenge_response;
         }
 
         // TODO: Generate an encrypted random session key

--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -204,9 +204,9 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
             );
         }
 
-        if (null !== $lm_hash && $calculate_lm_response) {
+        if (null !== $lm_hash && $calculate_lm_response || null !== $client_challenge) {
             $lm_challenge_response = $this->calculateLmResponse(
-                $lm_hash,
+                $lm_hash ?: $nt_hash,
                 $client_challenge,
                 $server_challenge_nonce
             );

--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -241,6 +241,10 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
     /**
      * Calculates the LM response.
      *
+     * TODO: Remove this method as it's no longer necessary.
+     *
+     * @deprecated This logic is now a simple pass-through to
+     *   {@link self::calculateChallengeResponseData()}.
      * @param HashCredentialInterface $hash_credential The user's authentication
      *   LM hash credential.
      * @param string|null $client_challenge A randomly generated 64-bit (8-byte)


### PR DESCRIPTION
Whoops! I forgot to handle the case in the NTLMv1 message encoder when an LM hash isn't provided or is supposed to be ignored.

This PR fixes that. :blush: 
