### PR TITLE
Bugfix - Target name overriding

### DIFF
--- a/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV1AuthenticateMessageEncoder.php
@@ -159,7 +159,7 @@ class NtlmV1AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
     ) {
         $negotiate_flags = $server_challenge->getNegotiateFlags();
         $server_challenge_nonce = $server_challenge->getNonce();
-        $target_name = $server_challenge->getTargetName() ?: $nt_domain;
+        $target_name = $nt_domain ?: $server_challenge->getTargetName();
 
         $client_challenge = null;
 

--- a/src/Robin/Ntlm/Message/NtlmV2AuthenticateMessageEncoder.php
+++ b/src/Robin/Ntlm/Message/NtlmV2AuthenticateMessageEncoder.php
@@ -138,7 +138,7 @@ class NtlmV2AuthenticateMessageEncoder extends AbstractAuthenticateMessageEncode
         $negotiate_flags = $server_challenge->getNegotiateFlags();
         $server_challenge_nonce = $server_challenge->getNonce();
         $target_info = $server_challenge->getTargetInfo();
-        $target_name = $server_challenge->getTargetName() ?: $nt_domain;
+        $target_name = $nt_domain ?: $server_challenge->getTargetName();
 
         // Generate a client challenge
         $client_challenge = $this->random_byte_generator->generate(static::CLIENT_CHALLENGE_LENGTH);


### PR DESCRIPTION
This PR fixes the fall-back order of the authentication message encoder's target name acquisition to allow for client overriding.

Or in other words, code that called `NtlmV1AuthenticateMessageEncoder::encode()` and/or `NtlmV2AuthenticateMessageEncoder:encode()` were unable to present a manual NT-domain/target-name, as the implementations were **always** taking the server's challenge message target-name as truth.

The reliance on the server challenge makes sense in a lot of cases, and still does if a user calls these methods with empty values, however it disallowed any sort of manual entry which is necessary in some multi-tenant service authentication environments.
