### PR TITLE
Chore: Fixing typos

### DIFF
--- a/src/Robin/Ntlm/Crypt/Random/McryptRandomByteGenerator.php
+++ b/src/Robin/Ntlm/Crypt/Random/McryptRandomByteGenerator.php
@@ -9,7 +9,6 @@
 namespace Robin\Ntlm\Crypt\Random;
 
 use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
-use UnexpectedValueException;
 
 /**
  * A cryptographically secure random byte generator implemented using the PHP
@@ -17,8 +16,9 @@ use UnexpectedValueException;
  *
  * @link http://php.net/mcrypt
  * @deprecated This implementation is deprecated, as the mcrypt library
- *   is abandoned. More info: https://github.com/robinpowered/php-ntlm/pull/1
- * @todo Remove this implementation in a future version.
+ *   is abandoned. Use {@link NativeRandomByteGenerator} instead.
+ *   More info: https://github.com/robinpowered/php-ntlm/pull/1
+ * @todo Mcrypt is abandoned and this should be removed in a future version.
  */
 class McryptRandomByteGenerator implements RandomByteGeneratorInterface
 {
@@ -68,7 +68,7 @@ class McryptRandomByteGenerator implements RandomByteGeneratorInterface
      * {@inheritDoc}
      *
      * @deprecated This implementation is deprecated, as the mcrypt
-     *   library is abandoned.
+     *   library is abandoned. Use {@link NativeRandomByteGenerator} instead.
      */
     public function generate($size)
     {

--- a/src/Robin/Ntlm/Crypt/Random/McryptRandomByteGenerator.php
+++ b/src/Robin/Ntlm/Crypt/Random/McryptRandomByteGenerator.php
@@ -16,7 +16,7 @@ use UnexpectedValueException;
  * "mcrypt" extension.
  *
  * @link http://php.net/mcrypt
- * @deprectated NOTE! This implementation is deprecated, as the mcrypt library
+ * @deprecated This implementation is deprecated, as the mcrypt library
  *   is abandoned. More info: https://github.com/robinpowered/php-ntlm/pull/1
  * @todo Remove this implementation in a future version.
  */
@@ -67,7 +67,7 @@ class McryptRandomByteGenerator implements RandomByteGeneratorInterface
     /**
      * {@inheritDoc}
      *
-     * @deprectated NOTE! This implementation is deprecated, as the mcrypt
+     * @deprecated This implementation is deprecated, as the mcrypt
      *   library is abandoned.
      */
     public function generate($size)

--- a/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
+++ b/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
@@ -15,7 +15,7 @@ use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
  * "openssl" extension.
  *
  * @link http://php.net/openssl
- * @deprectated NOTE! This implementation is deprecated, as it's been found to
+ * @deprecated Insecure! This implementation is deprecated, as it's been found to
  *   be insecure. More info: https://github.com/robinpowered/php-ntlm/issues/7
  * @todo Remove this implementation in a future version.
  */
@@ -29,7 +29,7 @@ class OpenSslRandomByteGenerator implements RandomByteGeneratorInterface
     /**
      * {@inheritDoc}
      *
-     * @deprectated NOTE! This implementation is deprecated, as it's been found
+     * @deprecated Insecure! This implementation is deprecated, as it's been found
      *   to be insecure.
      */
     public function generate($size)

--- a/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
+++ b/src/Robin/Ntlm/Crypt/Random/OpenSslRandomByteGenerator.php
@@ -15,9 +15,11 @@ use Robin\Ntlm\Crypt\Exception\CryptographicFailureException;
  * "openssl" extension.
  *
  * @link http://php.net/openssl
- * @deprecated Insecure! This implementation is deprecated, as it's been found to
- *   be insecure. More info: https://github.com/robinpowered/php-ntlm/issues/7
- * @todo Remove this implementation in a future version.
+ * @deprecated This implementation is deprecated, as it's been found to
+ *   be insecure. Use {@link NativeRandomByteGenerator} instead.
+ *   More info: https://github.com/robinpowered/php-ntlm/issues/7
+ * @todo This random byte generator is insecure due to an issue with
+ *   `openssl_random_pseudo_bytes`. It should be removed in a future version.
  */
 class OpenSslRandomByteGenerator implements RandomByteGeneratorInterface
 {
@@ -29,8 +31,8 @@ class OpenSslRandomByteGenerator implements RandomByteGeneratorInterface
     /**
      * {@inheritDoc}
      *
-     * @deprecated Insecure! This implementation is deprecated, as it's been found
-     *   to be insecure.
+     * @deprecated This implementation is deprecated, as it's been found
+     *   to be insecure. Use {@link RandomByteGeneratorInterface} instead.
      */
     public function generate($size)
     {


### PR DESCRIPTION
This is a followup to #8 which I prematurely, mistakenly merged to correct typos pointed out by @zachdunn.

I changed the `Note!`s too. For the abandoned ones the `@deprecated` tag should be enough. For the open SSL ones that are insecure i changed `Note!` to `Insecure!` to be a little more clear about why we're exclaiming `!`.
